### PR TITLE
small update to the essay page to make it the landing page.

### DIFF
--- a/content/essays/home.md
+++ b/content/essays/home.md
@@ -1,0 +1,9 @@
+---
+title: "Inquisito"
+date: "2017-09-18T23:19:51.246Z"
+slug: "essay"
+contentTop: "The materials featured on this website are from the University of Notre Dame&apos;s Harley L. McDevitt Inquisition Collection. The collection consists of several hundred items, from printed volumes to unique manuscripts and images, all bearing some relationship to the general theme of &quot;inquisition.&quot;"
+contentTopCard:
+  link: "/item/MSHLAT0090_EAD"
+  image: https://image-iiif.library.nd.edu/iiif/2/BPP1001_EAD%2FBPP_1001-001-F2/full/!250,250/0/default.jpg
+---

--- a/content/essays/manuals.md
+++ b/content/essays/manuals.md
@@ -16,7 +16,7 @@ featuredItems:
     link: "/item/MSHLAT0090_EAD"
     image: https://image-iiif.library.nd.edu/iiif/2/BPP1001_EAD%2FBPP_1001-001-F2/full/!250,250/0/default.jpg
 ---
-
+# Introduction to inquisitorial manuals
 ##Latin treatises on heresy and inquisition
 Conducting an inquisition was a complicated business. First inquisitors had to have some sense of their underlying theological justification and legal authority, both of which might well be challenged by hostile local forces. Then they had to be able to identify the various and often subtle types of heretical or otherwise sinful behavior which fell under their jurisdiction. Finally they had to know how to proceed in the practical exercise of their functions, from initial denunciation and arrest to questioning (including torture), judgment and punishment—all ideally subject to formal documentation. Inquisitors also had to manage a staff of underlings, each with their own particular duties and restrictions. Written instructions or policy statements were therefore important resources to ensure that established inquisitorial procedure was duly followed; these were sometimes collected into more or less comprehensive inquisitorial manuals and eventually they could be distributed in a variety of printed formats. The story of how and why these manuals appeared and changed over time is significant, suggesting much about how the inquisition’s institutional history intersected with broader histories of the book and histories of religious thought. Such documents also provide modern researchers with important primary source evidence for the history of medieval and early modern anti-heretical persecutions, by revealing how inquisitors were at least theoretically intended to function in a given time and place.
 

--- a/content/essays/manuals.md
+++ b/content/essays/manuals.md
@@ -1,13 +1,20 @@
 ---
 title: "Introduction to inquisitorial manuals"
-slug: "essays/inquisition-manuals"
+marbleId: "aspace_93b838c49d595bd0e9a87bcab723def2"
+slug: "item/aspace_93b838c49d595bd0e9a87bcab723def2"
 summary: "Inquisition practice through the ages was supposed to be governed by rules, policies, and complex legal and theological principles. Both theory and practice could vary over time, however, and many different types of manuals, guidebooks and brief procedural notices were circulated as tribunals and individual inquisitors continually strove to improve on their procedures. Closer examination of such texts reveals much about the institutions themselves, their members, and their ideological underpinnings."
 author: "Vose, Robin"
 citationYear: "2010"
 featuredItems:
-  - 1
-  - 2
-  - 3
+  - title: "Card #1"
+    link: "/item/MSHLAT0090_EAD"
+    image: https://image-iiif.library.nd.edu/iiif/2/BPP1001_EAD%2FBPP_1001-001-F2/full/!250,250/0/default.jpg
+  - title: "Card #2"
+    link: "/item/MSHLAT0090_EAD"
+    image: https://image-iiif.library.nd.edu/iiif/2/BPP1001_EAD%2FBPP_1001-001-F2/full/!250,250/0/default.jpg  
+  - title: "Card #3"
+    link: "/item/MSHLAT0090_EAD"
+    image: https://image-iiif.library.nd.edu/iiif/2/BPP1001_EAD%2FBPP_1001-001-F2/full/!250,250/0/default.jpg
 ---
 
 ##Latin treatises on heresy and inquisition

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -3,6 +3,34 @@ const path = require(`path`)
 exports.createPages = async ({ graphql, actions, reporter }) => {
   const { createPage } = actions
 
+  const marbleResult = await graphql(`
+    {
+      allMarbleItem {
+        nodes {
+          id
+          slug
+        }
+      }
+    }
+  `)
+
+  const marbleItems = marbleResult.data && marbleResult.data.allMarbleItem ? marbleResult.data.allMarbleItem.nodes : []
+  marbleItems.forEach(node => {
+    if (node.id) {
+      createPage({
+        path: node.slug,
+        component: path.resolve('./src/templates/marble-item.js'),
+        context: {
+          // Data passed to context is available
+          // in page queries as GraphQL variables.
+          slug: node.slug,
+          id: node.id,
+          iiifUri: node.iiifUri,
+        },
+      })
+    }
+  })
+
   // Define a template for blog post
   const essayTemplate = path.resolve(`src/templates/essay.js`)
 
@@ -55,32 +83,4 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
       })
     })
   }
-
-  const marbleResult = await graphql(`
-    {
-      allMarbleItem {
-        nodes {
-          id
-          slug
-        }
-      }
-    }
-  `)
-
-  const marbleItems = marbleResult.data && marbleResult.data.allMarbleItem ? marbleResult.data.allMarbleItem.nodes : []
-  marbleItems.forEach(node => {
-    if (node.id) {
-      createPage({
-        path: node.slug,
-        component: path.resolve('./src/templates/marble-item.js'),
-        context: {
-          // Data passed to context is available
-          // in page queries as GraphQL variables.
-          slug: node.slug,
-          id: node.id,
-          iiifUri: node.iiifUri,
-        },
-      })
-    }
-  })
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -45,7 +45,6 @@ const Home = ({ data, location }) => {
                 key={allMarbleItem.nodes[0]}
                 target='/item/MSHLAT0090_EAD'
                 image={typy(allMarbleItem.nodes[0], 'childrenMarbleFile[0].iiif.thumbnail').safeString}
-                type={allMarbleItem.nodes[0].display}
               >
                 <Link to='/item/MSHLAT0090_EAD'>Browse the Collection</Link>
               </Card>

--- a/src/templates/essay.js
+++ b/src/templates/essay.js
@@ -1,48 +1,72 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { graphql } from 'gatsby'
+import { graphql, Link } from 'gatsby'
 import queryString from 'query-string'
 import Layout from '../components/layouts/Default'
+import Card from '@ndlib/gatsby-theme-marble/src/components/Shared/Card'
 import Seo from '@ndlib/gatsby-theme-marble/src/components/Internal/Seo'
+import Column from 'components/Shared/Column'
+import MultiColumn from 'components/Shared/MultiColumn'
 
-export const MarbleItemPage = ({ data, location }) => {
+export const EssayPage = ({ data, location }) => {
   // use ?debug=true to render graphQL data at end of page
   const { debug } = queryString.parse(location.search)
+  const featuredItems = data.markdownRemark.frontmatter.featuredItems.map(item => {
+    return (<Card
+      key={item.link}
+      target={item.link}
+      image={item.image}
+      label={item.title}
+    />)
+  })
   return (
     <Layout location={location} title={data.markdownRemark.frontmatter.title}>
       <Seo
         data={data}
         location={location}
       />
-      <section>
-        <div>{data.markdownRemark.frontmatter.summary}</div>
-      </section>
-      <section>
-        <div dangerouslySetInnerHTML={{ __html: data.markdownRemark.html }} />
-      </section>
-      <section>
-        <hr />
-        <p>To cite this essay: </p>
-        <p>
-          {data.markdownRemark.frontmatter.author}. &quot;{data.markdownRemark.frontmatter.title}.&quot;
-          <em>Hesburgh Libraries of Notre Dame, Department of Rare Books and Special Collections</em>. University of Notre Dame,
-          {data.markdownRemark.frontmatter.citationYear}.&lt;https://inquisition.library.nd.edu/{data.markdownRemark.frontmatter.slug}&gt;
-        </p>
-      </section>
       {
         debug ? (
           <pre>{JSON.stringify(data, null, 2)}</pre>
         ) : null
       }
+      <MultiColumn columns='3'>
+        <Column colSpan='2'>
+          <section>
+            <div>{data.markdownRemark.frontmatter.summary}</div>
+          </section>
+          <section>
+            <div dangerouslySetInnerHTML={{ __html: data.markdownRemark.html }} />
+          </section>
+          <section>
+            <hr />
+            <p>To cite this essay: </p>
+            <p>
+              {data.markdownRemark.frontmatter.author}. &quot;{data.markdownRemark.frontmatter.title}.&quot;
+              <em>Hesburgh Libraries of Notre Dame, Department of Rare Books and Special Collections</em>. University of Notre Dame,
+              {data.markdownRemark.frontmatter.citationYear}.&lt;https://inquisition.library.nd.edu/{data.markdownRemark.frontmatter.slug}&gt;
+            </p>
+          </section>
+        </Column>
+        <Column>
+          <section>
+            <Link to='/search'>See all {data.markdownRemark.frontmatter.title} in the collection.</Link>
+          </section>
+          <section>
+            <h2>Featured Sources</h2>
+            {featuredItems}
+          </section>
+        </Column>
+      </MultiColumn>
     </Layout>
   )
 }
-MarbleItemPage.propTypes = {
+EssayPage.propTypes = {
   data: PropTypes.object.isRequired,
   location: PropTypes.object.isRequired,
 }
 
-export default MarbleItemPage
+export default EssayPage
 
 export const query = graphql`
   query($id: String!) {
@@ -55,7 +79,11 @@ export const query = graphql`
         slug
         summary
         author
-        featuredItems
+        featuredItems {
+          title
+          link
+          image
+        }
         citationYear
       }
     }


### PR DESCRIPTION
Important! 
To replace the collection landing page with the essay landing page.  I change the order that the routes are generated so that essay routes are generated after item routes and then replace the slug. 

Add an example of having featured sources on the essay page. 
